### PR TITLE
Merge dev changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*
+
+!.gitignore
+!LICENSE
+!README.md
+!coub.py

--- a/README.md
+++ b/README.md
@@ -32,68 +32,70 @@ CoubDownloader is a simple download script for coub.com
 Usage: coub.py [OPTIONS] INPUT [INPUT]...
 
 Input:
-  URL                    download coub(s) from the given URL
-  -i, --id ID            download a single coub
-  -l, --list PATH        read coub links from a text file
-  -c, --channel NAME     download coubs from a channel
-  -t, --tag TAG          download coubs with the specified tag
-  -e, --search TERM      download search results for the given term
-  -m, --community NAME   download coubs from a community
-                           NAME as seen in the URL (e.g. animals-pets)
-  --hot                  download coubs from the hot section (default sorting)
-  --random               download random coubs
-  --input-help           show full input help
+  URL                   download coub(s) from the given URL
+  -i, --id ID           download a single coub
+  -l, --list PATH       read coub links from a text file
+  -c, --channel NAME    download coubs from a channel
+  -t, --tag TAG         download coubs with the given tag
+  -e, --search TERM     download search results for the given term
+  -m, --community NAME  download coubs from a community
+                          NAME as seen in the URL (e.g. animals-pets)
+  --hot                 download coubs from the hot section (default sorting)
+  --random              download random coubs
+  --input-help          show full input help
 
     Input options do NOT support full URLs.
     Both URLs and input options support sorting (see --input-help).
 
 Common options:
-  -h, --help             show this help
-  -q, --quiet            suppress all non-error/prompt messages
-  -y, --yes              answer all prompts with yes
-  -n, --no               answer all prompts with no
-  -s, --short            disable video looping
-  -p, --path PATH        set output destination (def: '.')
-  -k, --keep             keep the individual video/audio parts
-  -r, --repeat N         repeat video N times (def: until audio ends)
-  -d, --duration TIME    specify max. coub duration (FFmpeg syntax)
+  -h, --help            show this help
+  -q, --quiet           suppress all non-error/prompt messages
+  -y, --yes             answer all prompts with yes
+  -n, --no              answer all prompts with no
+  -s, --short           disable video looping
+  -p, --path PATH       set output destination (def: '.')
+  -k, --keep            keep the individual video/audio parts
+  -r, --repeat N        repeat video N times (def: until audio ends)
+  -d, --duration TIME   specify max. coub duration (FFmpeg syntax)
 
 Download options:
-  --connections N        max. number of connections (def: 25)
-  --retries N            number of retries when connection is lost (def: 5)
-                           0 to disable, <0 to retry indefinitely
-  --limit-num LIMIT      limit max. number of downloaded coubs
+  --connections N       max. number of connections (def: 25)
+  --retries N           number of retries when connection is lost (def: 5)
+                          0 to disable, <0 to retry indefinitely
+  --limit-num LIMIT     limit max. number of downloaded coubs
 
 Format selection:
-  --bestvideo            download best available video quality (def)
-  --worstvideo           download worst available video quality
-  --max-video FORMAT     set limit for the best video format (def: higher)
-                           Supported values: med, high, higher
-  --min-video FORMAT     set limit for the worst video format (def: med)
-                           Supported values: med, high, higher
-  --bestaudio            download best available audio quality (def)
-  --worstaudio           download worst available audio quality
-  --aac                  prefer AAC over higher quality MP3 audio
-  --aac-strict           only download AAC audio (never MP3)
-  --share                download 'share' video (shorter and includes audio)
+  --bestvideo           download best available video quality (def)
+  --worstvideo          download worst available video quality
+  --max-video FORMAT    set limit for the best video format (def: higher)
+                          Supported values: med, high, higher
+  --min-video FORMAT    set limit for the worst video format (def: med)
+                          Supported values: med, high, higher
+  --bestaudio           download best available audio quality (def)
+  --worstaudio          download worst available audio quality
+  --aac                 prefer AAC over higher quality MP3 audio
+  --aac-strict          only download AAC audio (never MP3)
+  --share               download 'share' video (shorter and includes audio)
 
 Channel options:
-  --recoubs              include recoubs during channel downloads (def)
-  --no-recoubs           exclude recoubs during channel downloads
-  --only-recoubs         only download recoubs during channel downloads
+  --recoubs             include recoubs during channel downloads (def)
+  --no-recoubs          exclude recoubs during channel downloads
+  --only-recoubs        only download recoubs during channel downloads
 
 Preview options:
-  --preview COMMAND      play finished coub via the given command
-  --no-preview           explicitly disable coub preview
+  --preview COMMAND     play finished coub via the given command
+  --no-preview          explicitly disable coub preview
 
 Misc. options:
-  --audio-only           only download audio streams
-  --video-only           only download video streams
-  --write-list FILE      write all parsed coub links to FILE
-  --use-archive FILE     use FILE to keep track of already downloaded coubs
+  --audio-only          only download audio streams
+  --video-only          only download video streams
+  --write-list FILE     write all parsed coub links to FILE
+  --use-archive FILE    use FILE to keep track of already downloaded coubs
 
 Output:
-  -o, --output FORMAT    save output with the specified name (def: %id%)
+  --ext EXTENSION       merge output with the given extension (def: mkv)
+                          ignored if no merge is required
+  -o, --output FORMAT   save output with the given template (def: %id%)
 
     Special strings:
       %id%        - coub ID (identifier in the URL)
@@ -105,7 +107,6 @@ Output:
 
     Other strings will be interpreted literally.
     This option has no influence on the file extension.
-
 ```
 
 ## Requirements
@@ -411,7 +412,7 @@ It basically tells the script to rank AAC higher than anything else. On the othe
 
 Either an AAC stream is present or the audio will be entirely missing. This ensures AAC audio under any circumstances. Another way to look at it is that `--aac` tries to download AAC with MP3 as fallback, while `--aac-strict` gets rid of the fallback.
 
-To make matters even more complicated, some users might not want AAC audio at all. This is hopefully only a small demographic (after all AAC support is thorough and it does compress a lot better than MP3), but the script is still able to cater to this group. There's no extra command line option, but look for the following lines inside the script and change `aac` to 0.
+To make matters even more complicated, some users might not want AAC audio at all. This is hopefully only a small demographic (after all AAC support is thorough and it does compress a lot better than MP3), but the script is still able to cater to this group. There's no extra command line option, but look for the following lines inside the script and change `AAC` to 0.
 
 ```
     # How much to prefer AAC audio
@@ -419,7 +420,7 @@ To make matters even more complicated, some users might not want AAC audio at al
     # 1 -> rank it between low and high quality MP3
     # 2 -> prefer AAC, use MP3 fallback
     # 3 -> either AAC or no audio
-    aac = 1
+    AAC = 1
 ```
 
 Now AAC audio will be completely ignored and the script only serves MP3 audio (like the old version).
@@ -451,7 +452,7 @@ There's no fallback for *share* videos. If the *share* version is not yet availa
 
 Coub started to massively overhaul their database and API. Of course those changes aren't documented (why would you document API changes anyway?).
 
-- [x] Remove video repair (most videos are already stored in a non-broken state and the rest will soon follow)
+- [x] Only repair video streams that are actually broken
 - [x] Remove mobile option (they now come with a watermark and are the exact same as html5 med) 
 - [x] Add AAC mobile audio as another possible audio version (ranked between low and high quality MP3 audio)
 - [x] Add options to prefer AAC or only download AAC audio
@@ -469,7 +470,7 @@ Coub started to massively overhaul their database and API. Of course those chang
 - [x] Advanced sorting per input
 - [x] Support for sort order related URLs
 - [x] Download random coubs
-- [x] Advanced setting to change the container format for stream remuxing
+- [x] Option to change the container format for stream remuxing
 
 ## Changes since switching to Coub's API (previously used youtube-dl)
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ CoubDownloader is a simple script to download videos (called coubs) from [Coub](
 3.3. [Lists](https://github.com/HelpSeeker/CoubDownloader#lists)  
 3.4. [Channels](https://github.com/HelpSeeker/CoubDownloader#channels)  
 3.5. [Searches](https://github.com/HelpSeeker/CoubDownloader#searches)  
-3.6. [Tags](https://github.com/HelpSeeker/CoubDownloader#tags)  
-3.7. [Communities](https://github.com/HelpSeeker/CoubDownloader#communities)  
-3.8. [Hot section](https://github.com/HelpSeeker/CoubDownloader#hot-section)  
+3.6. [Random](https://github.com/HelpSeeker/CoubDownloader#random)  
+3.7. [Tags](https://github.com/HelpSeeker/CoubDownloader#tags)  
+3.8. [Communities](https://github.com/HelpSeeker/CoubDownloader#communities)  
+3.9. [Hot section](https://github.com/HelpSeeker/CoubDownloader#hot-section)  
 4. [Misc. information](https://github.com/HelpSeeker/CoubDownloader#misc-information)  
 4.1. [Video resolution vs. quality](https://github.com/HelpSeeker/CoubDownloader#video-resolution-vs-quality)  
 4.2. [AAC audio](https://github.com/HelpSeeker/CoubDownloader#aac-audio)  
@@ -39,7 +40,8 @@ Input:
   -e, --search TERM      download search results for the given term
   -m, --community NAME   download coubs from a community
                            NAME as seen in the URL (e.g. animals-pets)
-  --hot                  download coubs from the hot section
+  --hot                  download coubs from the hot section (default sorting)
+  --random               download random coubs
   --input-help           show full input help
 
     Input options do NOT support full URLs.
@@ -103,6 +105,7 @@ Output:
 
     Other strings will be interpreted literally.
     This option has no influence on the file extension.
+
 ```
 
 ## Requirements
@@ -139,11 +142,9 @@ Contents
   -) Channels
   -) Searches
   -) Tags
-  -) Communities (partially*)
+  -) Communities (incl. Featured & Coub of the Day)
   -) Hot section
-
-  * 'Featured' and 'Coub of the Day' are not yet supported as they use
-    different API endpoints.
+  -) Random
 
 2. Input Methods
 ================
@@ -156,7 +157,8 @@ Contents
     Search:       https://coub.com/search?q=example-term
     Tag:          https://coub.com/tags/example-tag
     Community:    https://coub.com/community/example-community
-    Hot section:  https://coub.com/hot
+    Hot section:  https://coub.com or https://coub.com/hot
+    Random:       https://coub.com/random
 
     URLs which indicate special sort orders are also supported.
 
@@ -169,6 +171,7 @@ Contents
     Tag:          -t example-tag        or  --tag example-tag
     Community:    -m example-community  or  --community example-community
     Hot section:  --hot
+    Random:       --random
 
   3) Prefix + channel name/tag/search term/etc.
 
@@ -181,6 +184,7 @@ Contents
     Tag:          tags/example-tag
     Community:    community/example-community
     Hot section:  hot
+    Random:       random
 
 3. Sorting
 ==========
@@ -203,49 +207,61 @@ Contents
 
     https://coub.com/search?q=example-term#top
     tags/example-tag#views_count
-    --hot#rising
+    hot#rising
 
-  This is supported by all input methods. Please note that a manually
-  specified sort order will overwrite the sort order as indicated by
-  the URL.
+  This is supported by all input methods, except the --hot option.
+  Please note that a manually specified sort order will overwrite the
+  sort order as indicated by the URL.
 
   Supported sort orders
   ---------------------
 
-    Channels:     most_recent (default)
-                  most_liked
-                  most_viewed
-                  oldest
-                  random
+    Channels:         most_recent (default)
+                      most_liked
+                      most_viewed
+                      oldest
+                      random
 
-    Searches:     relevance (default)
-                  top
-                  views_count
-                  most_recent
+    Searches:         relevance (default)
+                      top
+                      views_count
+                      most_recent
 
-    Tags:         popular (default)
-                  top
-                  views_count
-                  fresh
+    Tags:             popular (default)
+                      top
+                      views_count
+                      fresh
 
-    Communities:  hot_daily
-                  hot_weekly
-                  hot_monthly (default)
-                  hot_quarterly
-                  hot_six_months
-                  rising
-                  fresh
-                  top
-                  views_count
-                  random
+    Communities:      hot_daily
+                      hot_weekly
+                      hot_monthly (default)
+                      hot_quarterly
+                      hot_six_months
+                      rising
+                      fresh
+                      top
+                      views_count
+                      random
 
-    Hot section:  hot_daily
-                  hot_weekly
-                  hot_monthly (default)
-                  hot_quarterly
-                  hot_six_months
-                  rising
-                  fresh
+    Featured:         recent (default)
+    (community)       top_of_the_month
+                      undervalued
+
+    Coub of the Day:  recent (default)
+    (community)       top
+                      views_count
+
+    Hot section:      hot_daily
+                      hot_weekly
+                      hot_monthly (default)
+                      hot_quarterly
+                      hot_six_months
+                      rising
+                      fresh
+
+    Random:           popular (default)
+                      top
+
 ```
 
 ***
@@ -286,6 +302,10 @@ Searches provide the same results as on Coub's website, with the exception that 
 
 Using general search terms can potentially return tens of thousands of coub links. The usage of `--limit-num` is encouraged.
 
+#### Random
+
+Provides a random collection of coubs. A request returns max. 1000 coubs, but several requests can be made during one script invocation (e.g. using the --random option thrice).
+
 ***
 
 The now following input types only return a limited number of links. This is indirectly enforced by the API, although I can't say if it is done on purpose or a bug (pages >99 redirect to page 1).
@@ -302,7 +322,7 @@ Please note that the default sort order (by popularity) provides less results th
 
 #### Communities
 
-There are currently 17 supported communities.
+There are currently 19 supported communities.
 
 The following list shows the names of the supported communities (as seen on Coub's website). In parenthesis are the internally used names and what should be used as input for the script.
 
@@ -323,8 +343,12 @@ The following list shows the names of the supported communities (as seen on Coub
 * Dance                (**dance**)
 * Auto & Technique     (**cars**)
 * NSFW                 (**nsfw**)
+* Featured             (**featured**)
+* Coub of the Day      (**coub-of-the-day**)
 
-The default sort order (most popular coubs of the month) may provide less results than other sort orders.
+The default sort order for most communities (most popular coubs of the month) may provide less results than other sort orders.
+
+*Featured* and *Coub of the Day* have unique sort orders.
 
 #### Hot section
 
@@ -433,7 +457,7 @@ Coub started to massively overhaul their database and API. Of course those chang
 - [x] Add options to prefer AAC or only download AAC audio
 - [x] Add shared option (video+audio already combined)
 - [x] Download coubs from the hot section
-- [x] Download coubs from communities
+- [x] Download coubs from communities (incl. Featured & Coub of the Day)
 - [x] Asynchronous coub processing
 - [x] Asynchronous timeline parsing
 - [x] Detect stream corruption (incl. old Coub storage method)
@@ -444,6 +468,8 @@ Coub started to massively overhaul their database and API. Of course those chang
 - [x] Autocompletion of incomplete/malformed URLs (to some extent)
 - [x] Advanced sorting per input
 - [x] Support for sort order related URLs
+- [x] Download random coubs
+- [x] Advanced setting to change the container format for stream remuxing
 
 ## Changes since switching to Coub's API (previously used youtube-dl)
 

--- a/coub.py
+++ b/coub.py
@@ -85,34 +85,34 @@ class DefaultOptions:
 
     # Change verbosity of the script
     # 0 for quiet, >= 1 for normal verbosity
-    verbosity = 1
+    VERBOSITY = 1
 
     # yes/no will answer prompts automatically
     # Everything else will lead to a prompt
-    prompt_answer = None
+    PROMPT = None
 
     # Default download destination
-    path = "."
+    PATH = "."
 
     # Keep individual video/audio streams
-    keep = False
+    KEEP = False
 
     # How often to loop the video
     # Only has an effect, if the looped video is shorter than the audio
     # Otherwise the max. length is limited by the audio duration
-    repeat = 1000
+    REPEAT = 1000
 
     # Max. coub duration (FFmpeg syntax)
     # Can be used in combination with repeat, in which case the shorter
     # duration will be used
-    dur = None
+    DUR = None
 
     # Max no. of connections for aiohttp's ClientSession
     # Raising this value can lead to shorter download times, but also
     # increases the risk of Coub throttling or terminating your connections
     # There's also no benefit in higher values, if your connection is already
     # fully utilized
-    connect = 25
+    CONNECT = 25
 
     # How often to retry download when connection is lost
     # >0 -> retry the specified number of times
@@ -120,65 +120,63 @@ class DefaultOptions:
     # <0 -> retry indefinitely
     # Retries happen through recursion, so the max. number is theoretically
     # limited to 1000 retries (although Python's limit could be raised as well)
-    retries = 5
+    RETRIES = 5
 
     # Limit how many coubs can be downloaded during one script invocation
-    max_coubs = None
+    MAX_COUBS = None
 
     # What video/audio quality to download
     #   0 -> worst quality
     #  -1 -> best quality
     # Everything else can lead to undefined behavior
-    v_quality = -1
-    a_quality = -1
+    V_QUALITY = -1
+    A_QUALITY = -1
 
     # Limits for the list of video streams
-    #   v_max: limits what counts as best stream
-    #   v_min: limits what counts as worst stream
+    #   V_MAX: limits what counts as best stream
+    #   V_MIN: limits what counts as worst stream
     # Supported values:
     #   med    ( ~640px width)
     #   high   (~1280px width)
     #   higher (~1600px width)
-    v_max = 'higher'
-    v_min = 'med'
+    V_MAX = 'higher'
+    V_MIN = 'med'
 
     # How much to prefer AAC audio
     #   0 -> never download AAC audio
     #   1 -> rank it between low and high quality MP3
     #   2 -> prefer AAC, use MP3 fallback
     #   3 -> either AAC or no audio
-    aac = 1
+    AAC = 1
 
     # Use shared video+audio instead of merging separate streams
     # Leads to shorter videos, also no further quality selection
-    share = False
+    SHARE = False
 
     # How to treat recoubs during channel downloads
-    #   recoubs = False     -> Only Original
-    #   recoubs = True      -> Original + Recoubs
-    #   only_recoubs = True -> Only Recoubs
-    # recoubs mustn't be False, when only_recoubs is True
-    recoubs = True
-    only_recoubs = False
+    #   RECOUBS = False     -> Only Original
+    #   RECOUBS = True      -> Original + Recoubs
+    #   ONLY_RECOUBS = True -> Only Recoubs
+    # RECOUBS mustn't be False, when ONLY_RECOUBS is True
+    RECOUBS = True
+    ONLY_RECOUBS = False
 
     # Preview a downloaded coub with the given command
     # Keyboard shortcuts may not work for CLI audio players
-    preview = None
+    PREVIEW = None
 
     # Only download video/audio stream
-    # a_only and v_only are mutually exclusive
-    a_only = False
-    v_only = False
+    # A_ONLY and V_ONLY are mutually exclusive
+    A_ONLY = False
+    V_ONLY = False
 
     # Output parsed coubs to file instead of downloading
     # Values other than None will terminate the script after the initial
     # parsing process (i.e. no coubs will be downloaded)
-    out_file = None
+    OUT_FILE = None
 
     # Use an archive file to keep track of downloaded coubs
-    #   archive_path -> path to the archive
-    #   archive      -> content of the archive
-    archive_path = None
+    ARCHIVE_PATH = None
 
     # Output name formatting (default: %id%)
     # Supports the following special keywords:
@@ -192,7 +190,7 @@ class DefaultOptions:
     #
     # Setting a custom value increases skip duration for existing coubs
     # Usage of an archive file is recommended in such an instance
-    out_format = None
+    OUT_FORMAT = None
 
 
 class InputHelp(argparse.Action):
@@ -1279,71 +1277,71 @@ def parse_cli():
     parser.add_argument("--input-help", action=InputHelp)
     # Common Options
     parser.add_argument("-q", "--quiet", dest="verbosity", action="store_const",
-                        const=0, default=defaults.verbosity)
+                        const=0, default=defaults.VERBOSITY)
     prompt = parser.add_mutually_exclusive_group()
-    prompt.add_argument("-y", "--yes", dest="prompt_answer", action="store_const",
-                        const="yes", default=defaults.prompt_answer)
-    prompt.add_argument("-n", "--no", dest="prompt_answer", action="store_const",
-                        const="no", default=defaults.prompt_answer)
+    prompt.add_argument("-y", "--yes", dest="prompt", action="store_const",
+                        const="yes", default=defaults.PROMPT)
+    prompt.add_argument("-n", "--no", dest="prompt", action="store_const",
+                        const="no", default=defaults.PROMPT)
     repeat = parser.add_mutually_exclusive_group()
     repeat.add_argument("-s", "--short", dest="repeat", action="store_const",
-                        const=1, default=defaults.repeat)
-    repeat.add_argument("-r", "--repeat", type=positive_int, default=defaults.repeat)
-    parser.add_argument("-p", "--path", default=defaults.path)
-    parser.add_argument("-k", "--keep", action="store_true", default=defaults.keep)
+                        const=1, default=defaults.REPEAT)
+    repeat.add_argument("-r", "--repeat", type=positive_int, default=defaults.REPEAT)
+    parser.add_argument("-p", "--path", default=defaults.PATH)
+    parser.add_argument("-k", "--keep", action="store_true", default=defaults.KEEP)
     parser.add_argument("-d", "--duration", dest="dur", type=valid_time,
-                        default=defaults.dur)
+                        default=defaults.DUR)
     # Download Options
     parser.add_argument("--connections", dest="connect", type=positive_int,
-                        default=defaults.connect)
-    parser.add_argument("--retries", type=int, default=defaults.retries)
+                        default=defaults.CONNECT)
+    parser.add_argument("--retries", type=int, default=defaults.RETRIES)
     parser.add_argument("--limit-num", dest="max_coubs", type=positive_int,
-                        default=defaults.max_coubs)
+                        default=defaults.MAX_COUBS)
     # Format Selection
     v_qual = parser.add_mutually_exclusive_group()
     v_qual.add_argument("--bestvideo", dest="v_quality", action="store_const",
-                        const=-1, default=defaults.v_quality)
+                        const=-1, default=defaults.V_QUALITY)
     v_qual.add_argument("--worstvideo", dest="v_quality", action="store_const",
-                        const=0, default=defaults.v_quality)
+                        const=0, default=defaults.V_QUALITY)
     a_qual = parser.add_mutually_exclusive_group()
     a_qual.add_argument("--bestaudio", dest="a_quality", action="store_const",
-                        const=-1, default=defaults.a_quality)
+                        const=-1, default=defaults.A_QUALITY)
     a_qual.add_argument("--worstaudio", dest="a_quality", action="store_const",
-                        const=0, default=defaults.a_quality)
-    parser.add_argument("--max-video", dest="v_max", default=defaults.v_max,
+                        const=0, default=defaults.A_QUALITY)
+    parser.add_argument("--max-video", dest="v_max", default=defaults.V_MAX,
                         choices=["med", "high", "higher"])
-    parser.add_argument("--min-video", dest="v_min", default=defaults.v_min,
+    parser.add_argument("--min-video", dest="v_min", default=defaults.V_MIN,
                         choices=["med", "high", "higher"])
     aac = parser.add_mutually_exclusive_group()
-    aac.add_argument("--aac", action="store_const", const=2, default=defaults.aac)
+    aac.add_argument("--aac", action="store_const", const=2, default=defaults.AAC)
     aac.add_argument("--aac-strict", dest="aac", action="store_const", const=3,
-                     default=defaults.aac)
+                     default=defaults.AAC)
     # Channel Options
     recoub = parser.add_mutually_exclusive_group()
-    recoub.add_argument("--recoubs", action="store_true", default=defaults.recoubs)
+    recoub.add_argument("--recoubs", action="store_true", default=defaults.RECOUBS)
     recoub.add_argument("--no-recoubs", dest="recoubs", action="store_false",
-                        default=defaults.recoubs)
+                        default=defaults.RECOUBS)
     recoub.add_argument("--only-recoubs", action="store_true",
-                        default=defaults.only_recoubs)
+                        default=defaults.ONLY_RECOUBS)
     # Preview Options
     player = parser.add_mutually_exclusive_group()
-    player.add_argument("--preview", default=defaults.preview)
+    player.add_argument("--preview", default=defaults.PREVIEW)
     player.add_argument("--no-preview", dest="preview", action="store_const",
-                        const=None, default=defaults.preview)
+                        const=None, default=defaults.PREVIEW)
     # Misc. Options
     stream = parser.add_mutually_exclusive_group()
     stream.add_argument("--audio-only", dest="a_only", action="store_true",
-                        default=defaults.a_only)
+                        default=defaults.A_ONLY)
     stream.add_argument("--video-only", dest="v_only", action="store_true",
-                        default=defaults.v_only)
-    stream.add_argument("--share", action="store_true", default=defaults.share)
+                        default=defaults.V_ONLY)
+    stream.add_argument("--share", action="store_true", default=defaults.SHARE)
     parser.add_argument("--write-list", dest="out_file", type=os.path.abspath,
-                        default=defaults.out_file)
+                        default=defaults.OUT_FILE)
     parser.add_argument("--use-archive", dest="archive_path", type=valid_archive,
-                        default=defaults.archive_path)
+                        default=defaults.ARCHIVE_PATH)
     # Output
     parser.add_argument("-o", "--output", dest="out_format",
-                        default=defaults.out_format)
+                        default=defaults.OUT_FORMAT)
 
     # Advanced Options
     parser.set_defaults(
@@ -1536,9 +1534,9 @@ def exists(name):
 
 def overwrite(name):
     """Prompt the user if they want to overwrite an existing coub."""
-    if opts.prompt_answer == "yes":
+    if opts.prompt == "yes":
         return True
-    elif opts.prompt_answer == "no":
+    elif opts.prompt == "no":
         return False
     else:
         # this should get printed even with --quiet

--- a/coub.py
+++ b/coub.py
@@ -197,6 +197,11 @@ class Options:
     coubs_per_page = 25       # allowed: 1-25
     tag_sep = "_"
 
+    # How to open output lists (--write-list)
+    #   w -> overwrite file
+    #   a -> append to file
+    write_method = "w"
+
     # Container to mux video/audio into (must support AVC, MP3 and AAC)
     merge_ext = "mkv"
 
@@ -595,7 +600,7 @@ class CoubInputData:
             msg(f"  {total} link{'s' if total != 1 else ''}")
 
         if opts.out_file:
-            with open(opts.out_file, "a") as f:
+            with open(opts.out_file, opts.write_method) as f:
                 for link in self.parsed:
                     print(link, file=f)
             msg(f"\nParsed coubs written to '{opts.out_file}'!",

--- a/coub.py
+++ b/coub.py
@@ -1398,7 +1398,7 @@ def parse_cli():
     repeat.add_argument("-s", "--short", dest="repeat", action="store_const",
                         const=1, default=defaults.REPEAT)
     repeat.add_argument("-r", "--repeat", type=positive_int, default=defaults.REPEAT)
-    parser.add_argument("-p", "--path", default=defaults.PATH)
+    parser.add_argument("-p", "--path", type=os.path.abspath, default=defaults.PATH)
     parser.add_argument("-k", "--keep", action="store_true", default=defaults.KEEP)
     parser.add_argument("-d", "--duration", dest="dur", type=valid_time,
                         default=defaults.DUR)

--- a/coub.py
+++ b/coub.py
@@ -201,6 +201,7 @@ class InputHelp(argparse.Action):
 
     def __init__(self, **kwargs):
         super(InputHelp, self).__init__(nargs=0, **kwargs)
+
     def __call__(self, parser, namespace, values, option_string=None):
         parser.print_input_help()
         parser.exit()
@@ -1063,7 +1064,7 @@ def check_connection():
 def no_url(string):
     """Test if direct input is an URL."""
     if "coub.com" in string:
-        raise ValueError("input options don't support URLs")
+        raise argparse.ArgumentTypeError("input options don't support URLs")
     return string
 
 

--- a/coub.py
+++ b/coub.py
@@ -1579,7 +1579,6 @@ def write_list(links):
             print(l, file=f)
     msg(f"\nParsed coubs written to '{opts.out_file}'!",
         color=fgcolors.SUCCESS)
-    sys.exit(0)
 
 
 def get_name(req_json, c_id):
@@ -1906,6 +1905,7 @@ def main():
     links = parse_input(opts.input)
     if opts.out_file:
         write_list(links)
+        sys.exit(0)
     total = len(links)
     coubs = [Coub(l) for l in links]
 

--- a/coub.py
+++ b/coub.py
@@ -521,8 +521,6 @@ class CoubInputData:
     links = []
     containers = []
     parsed = []
-    # This keeps track of the initial size of parsed for progress messages
-    count = 0
 
     def append_container(self, to_add):
         """Append timelines if they don't already exist."""
@@ -606,10 +604,6 @@ class CoubInputData:
             msg(f"\nParsed coubs written to '{opts.out_file}'!",
                 color=fgcolors.SUCCESS)
             sys.exit(0)
-
-    def update_count(self):
-        """Keep track of the initial number of parsed links."""
-        self.count = len(self.parsed)
 
 
 class Coub:
@@ -848,7 +842,7 @@ class Coub:
 
         # Log status after processing
         count += 1
-        progress = f"[{count: >{len(str(user_input.count))}}/{user_input.count}]"
+        progress = f"[{count: >{len(str(len(user_input.parsed)))}}/{len(user_input.parsed)}]"
         if self.unavailable:
             err(f"  {progress} {self.link: <30} ... ", color=fgcolors.RESET, end="")
             err("unavailable")
@@ -1787,12 +1781,9 @@ def main():
 
     msg("\n### Parse Input ###")
     user_input.parse_input()
-    user_input.update_count()
 
     msg("\n### Download Coubs ###\n")
-
     coubs = [Coub(l) for l in user_input.parsed]
-
     try:
         attempt_process(coubs)
     finally:

--- a/coub.py
+++ b/coub.py
@@ -7,7 +7,6 @@ import os
 import subprocess
 import sys
 
-from fnmatch import fnmatch
 from math import ceil
 from textwrap import dedent
 
@@ -1238,10 +1237,11 @@ def mapped_input(string):
     elif "https://coub.com/community/" in link:
         name = link.partition("https://coub.com/community/")[2]
         source = Community(name)
-    elif fnmatch(link, "https://coub.com#*") or \
-         fnmatch(link, "https://coub.com/hot*") or \
-         link == "https://coub.com":
-        source = HotSection(link)
+    elif "https://coub.com/hot" in link or \
+         "https://coub.com#" in link or \
+         link.strip("/") == "https://coub.com":
+        sort = link.partition("https://coub.com")[2]
+        source = HotSection(sort)
     # Unfortunately channel URLs don't have any special characteristics
     # and are basically the fallthrough link type
     else:

--- a/coub.py
+++ b/coub.py
@@ -1544,23 +1544,20 @@ def overwrite(name):
     """Prompt the user if they want to overwrite an existing coub."""
     if opts.prompt == "yes":
         return True
-    elif opts.prompt == "no":
+    if opts.prompt == "no":
         return False
-    else:
-        # this should get printed even with --quiet
-        # so print() instead of msg()
-        if name:
-            print(f"Overwrite file? ({name})")
-        else:
-            print("Overwrite file?")
-        print("1) yes")
-        print("2) no")
-        while True:
-            answer = input("#? ")
-            if answer == "1":
-                return True
-            if answer == "2":
-                return False
+
+    # this should get printed even with --quiet
+    # so print() instead of msg()
+    print(f"Overwrite file? ({name})")
+    print("1) yes")
+    print("2) no")
+    while True:
+        answer = input("#? ")
+        if answer == "1":
+            return True
+        if answer == "2":
+            return False
 
 
 def stream_lists(resp_json):

--- a/coub.py
+++ b/coub.py
@@ -36,48 +36,7 @@ except ModuleNotFoundError:
         colors = False
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Global constants
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-class ExitCodes:
-    """Store exit codes for non-successful execution."""
-
-    DEP = 1         # missing required software
-    OPT = 2         # invalid user-specified option
-    RUN = 3         # misc. runtime error
-    DOWN = 4        # failed to download all input links (existence == success)
-    INT = 5         # early termination was requested by the user (i.e. Ctrl+C)
-    CONN = 6        # connection either couldn't be established or was lost
-
-
-class Colors:
-    """Store ANSI escape codes for colorized output."""
-
-    # https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
-    ERROR = '\033[31m'      # red
-    WARNING = '\033[33m'    # yellow
-    SUCCESS = '\033[32m'    # green
-    RESET = '\033[0m'
-
-    def disable(self):
-        """Disable colorized output by removing escape codes."""
-        # I'm not going to stop addressing these attributes as constants, just
-        # because Windows thinks it needs to be special
-        self.ERROR = ''
-        self.SUCCESS = ''
-        self.WARNING = ''
-        self.RESET = ''
-
-
-# Create objects to hold constants
-status = ExitCodes()
-fgcolors = Colors()
-
-if not colors:
-    fgcolors.disable()
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Classes
+# Default Options
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 class DefaultOptions:
@@ -192,6 +151,55 @@ class DefaultOptions:
     # Usage of an archive file is recommended in such an instance
     OUT_FORMAT = None
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Classes For Global Variables
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class ExitCodes:
+    """Store exit codes for non-successful execution."""
+
+    DEP = 1         # missing required software
+    OPT = 2         # invalid user-specified option
+    RUN = 3         # misc. runtime error
+    DOWN = 4        # failed to download all input links (existence == success)
+    INT = 5         # early termination was requested by the user (i.e. Ctrl+C)
+    CONN = 6        # connection either couldn't be established or was lost
+
+
+class Colors:
+    """Store ANSI escape codes for colorized output."""
+
+    # https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+    ERROR = '\033[31m'      # red
+    WARNING = '\033[33m'    # yellow
+    SUCCESS = '\033[32m'    # green
+    RESET = '\033[0m'
+
+    def disable(self):
+        """Disable colorized output by removing escape codes."""
+        # I'm not going to stop addressing these attributes as constants, just
+        # because Windows thinks it needs to be special
+        self.ERROR = ''
+        self.SUCCESS = ''
+        self.WARNING = ''
+        self.RESET = ''
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Global Variables
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+status = ExitCodes()
+fgcolors = Colors()
+if not colors:
+    fgcolors.disable()
+
+total = 0
+count = 0
+done = 0
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Classes
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 class InputHelp(argparse.Action):
     """Custom action to print input help."""
@@ -1779,7 +1787,6 @@ def main():
     global total
 
     check_prereq()
-    parse_cli()
     check_options()
     resolve_paths()
     check_connection()
@@ -1801,10 +1808,6 @@ def main():
 # Execute main function
 if __name__ == '__main__':
     opts = parse_cli()
-    total = 0
-    count = 0
-    done = 0
-
     try:
         main()
     except KeyboardInterrupt:

--- a/coub.py
+++ b/coub.py
@@ -232,7 +232,6 @@ class Options:
 
     # Input-related (don't touch)
     input = []
-    links = []
 
 
 class BaseContainer:
@@ -752,7 +751,7 @@ class Coub:
 
         # Log status after processing
         count += 1
-        progress = f"[{count: >{len(str(len(opts.links)))}}/{len(opts.links)}]"
+        progress = f"[{count: >{len(str(total))}}/{total}]"
         if self.unavailable:
             err(f"  {progress} {self.link: <30} ... ", color=fgcolors.RESET, end="")
             err("unavailable")
@@ -1451,20 +1450,20 @@ def parse_input(sources):
         msg(f"\nDownload limit ({opts.max_coubs}) reached!",
             color=fgcolors.WARNING)
 
-    total = len(parsed)
-    # Weed out duplicates
-    parsed = list(set(parsed))
-    dupes = total - len(parsed)
+    before = len(parsed)
+    parsed = list(set(parsed))      # Weed out duplicates
+    after = len(parsed)
+    dupes = before - after
     if dupes:
         msg(dedent(f"""
             Results:
-              {total} input link{'s' if total != 1 else ''}
+              {before} input link{'s' if before != 1 else ''}
               {dupes} duplicate{'s' if dupes != 1 else ''}
-              {len(parsed)} final link{'s' if len(parsed) != 1 else ''}"""))
+              {after} final link{'s' if after != 1 else ''}"""))
     else:
         msg(dedent(f"""
             Results:
-              {total} link{'s' if total != 1 else ''}"""))
+              {after} link{'s' if after != 1 else ''}"""))
 
     if opts.out_file:
         with open(opts.out_file, opts.write_method) as f:
@@ -1785,6 +1784,8 @@ def attempt_process(coubs, level=0):
 
 def main():
     """Download all requested coubs."""
+    global total
+
     check_prereq()
     parse_cli()
     check_options()
@@ -1792,10 +1793,11 @@ def main():
     check_connection()
 
     msg("\n### Parse Input ###")
-    opts.links = parse_input(opts.input)
+    links = parse_input(opts.input)
+    total = len(links)
+    coubs = [Coub(l) for l in links]
 
     msg("\n### Download Coubs ###\n")
-    coubs = [Coub(l) for l in opts.links]
     try:
         attempt_process(coubs)
     finally:
@@ -1807,6 +1809,7 @@ def main():
 # Execute main function
 if __name__ == '__main__':
     opts = Options()
+    total = 0
     count = 0
     done = 0
 

--- a/coub.py
+++ b/coub.py
@@ -561,24 +561,6 @@ class CoubInputData:
             msg("\nReading command line:")
             msg(f"  {len(self.links)} link{'s' if len(self.links) != 1 else ''} found")
 
-    def find_dupes(self):
-        """Find and remove duplicates from the parsed coub link list."""
-        dupes = 0
-
-        self.parsed.sort()
-        last = self.parsed[-1]
-
-        # There are faster and more elegant ways to do this
-        # but I also want to keep track of how many dupes were found
-        for i in range(len(self.parsed)-2, -1, -1):
-            if last == self.parsed[i]:
-                dupes += 1
-                del self.parsed[i]
-            else:
-                last = self.parsed[i]
-
-        return dupes
-
     def parse_input(self):
         """Handle the parsing process of all provided input sources."""
         self.parse_links()
@@ -599,15 +581,18 @@ class CoubInputData:
             msg(f"\nDownload limit ({opts.max_coubs}) reached!",
                 color=fgcolors.WARNING)
 
-        dupes = self.find_dupes()
+        total = len(self.parsed)
+        # Weed out duplicates
+        self.parsed = list(set(self.parsed))
+        dupes = total - len(self.parsed)
         if dupes:
             msg("\nResults:")
-            msg(f"  {len(self.parsed)} input link{'s' if len(self.parsed) != 1 else ''}")
+            msg(f"  {total} input link{'s' if total != 1 else ''}")
             msg(f"  {dupes} duplicate{'s' if dupes != 1 else ''}")
             msg(f"  {len(self.parsed)} final link{'s' if len(self.parsed) != 1 else ''}")
         else:
             msg("\nResults:")
-            msg(f"  {len(self.parsed)} link{'s' if len(self.parsed) != 1 else ''}")
+            msg(f"  {total} link{'s' if total != 1 else ''}")
 
         if opts.out_file:
             with open(opts.out_file, "a") as f:

--- a/coub.py
+++ b/coub.py
@@ -1465,15 +1465,17 @@ def parse_input(sources):
             Results:
               {after} link{'s' if after != 1 else ''}"""))
 
-    if opts.out_file:
-        with open(opts.out_file, opts.write_method) as f:
-            for link in parsed:
-                print(link, file=f)
-        msg(f"\nParsed coubs written to '{opts.out_file}'!",
-            color=fgcolors.SUCCESS)
-        sys.exit(0)
-
     return parsed
+
+
+def write_list(links):
+    """Output parsed links to a list and exit."""
+    with open(opts.out_file, opts.write_method) as f:
+        for l in links:
+            print(l, file=f)
+    msg(f"\nParsed coubs written to '{opts.out_file}'!",
+        color=fgcolors.SUCCESS)
+    sys.exit(0)
 
 
 def get_name(req_json, c_id):
@@ -1790,6 +1792,8 @@ def main():
 
     msg("\n### Parse Input ###")
     links = parse_input(opts.input)
+    if opts.out_file:
+        write_list(links)
     total = len(links)
     coubs = [Coub(l) for l in links]
 

--- a/coub.py
+++ b/coub.py
@@ -326,11 +326,8 @@ class CustomArgumentParser(argparse.ArgumentParser):
           -) Channels
           -) Searches
           -) Tags
-          -) Communities (partially*)
+          -) Communities (incl. Featured & Coub of the Day)
           -) Hot section
-
-          * 'Coub of the Day' is not yet supported as it uses a different API
-            endpoint.
 
         2. Input Methods
         ================
@@ -399,44 +396,48 @@ class CustomArgumentParser(argparse.ArgumentParser):
           Supported sort orders
           ---------------------
 
-            Channels:     most_recent (default)
-                          most_liked
-                          most_viewed
-                          oldest
-                          random
+            Channels:         most_recent (default)
+                              most_liked
+                              most_viewed
+                              oldest
+                              random
 
-            Searches:     relevance (default)
-                          top
-                          views_count
-                          most_recent
+            Searches:         relevance (default)
+                              top
+                              views_count
+                              most_recent
 
-            Tags:         popular (default)
-                          top
-                          views_count
-                          fresh
+            Tags:             popular (default)
+                              top
+                              views_count
+                              fresh
 
-            Communities:  hot_daily
-                          hot_weekly
-                          hot_monthly (default)
-                          hot_quarterly
-                          hot_six_months
-                          rising
-                          fresh
-                          top
-                          views_count
-                          random
+            Communities:      hot_daily
+                              hot_weekly
+                              hot_monthly (default)
+                              hot_quarterly
+                              hot_six_months
+                              rising
+                              fresh
+                              top
+                              views_count
+                              random
 
-            Featured:     recent
-            (community)   top_of_the_month
-                          undervalued
+            Featured:         recent (default)
+            (community)       top_of_the_month
+                              undervalued
 
-            Hot section:  hot_daily
-                          hot_weekly
-                          hot_monthly (default)
-                          hot_quarterly
-                          hot_six_months
-                          rising
-                          fresh
+            Coub of the Day:  recent (default)
+            (community)       top
+                              views_count
+
+            Hot section:      hot_daily
+                              hot_weekly
+                              hot_monthly (default)
+                              hot_quarterly
+                              hot_six_months
+                              rising
+                              fresh
         """)
 
         return help_text
@@ -656,7 +657,7 @@ class Community(BaseContainer):
         #                 hot_six_months, rising, fresh, top, views_count, random
         # Coub's default: hot_monthly
         if not self.sort:
-            if self.id == "featured":
+            if self.id in ("featured", "coub-of-the-day"):
                 self.sort = "recent"
             else:
                 self.sort = "hot_monthly"
@@ -670,6 +671,13 @@ class Community(BaseContainer):
                 'undervalued': "undervalued",
             }
             template = "https://coub.com/api/v2/timeline/explore?"
+        elif self.id == "coub-of-the-day":
+            methods = {
+                'recent': None,
+                'top': "top",
+                'views_count': "views_count",
+            }
+            template = "https://coub.com/api/v2/timeline/explore/coub_of_the_day?"
         else:
             methods = {
                 'hot_daily': "daily",
@@ -691,7 +699,7 @@ class Community(BaseContainer):
             self.valid = False
             return
 
-        if self.id == "featured":
+        if self.id in ("featured", "coub-of-the-day"):
             if self.sort != "recent":
                 template = f"{template}order_by={methods[self.sort]}&"
         else:

--- a/coub.py
+++ b/coub.py
@@ -1522,10 +1522,26 @@ async def parse_page(req, session=None):
     return [f"https://coub.com/view/{i}" for i in ids]
 
 
+def remove_container_dupes(containers):
+    """Remove duplicate containers to avoid unnecessary parsing."""
+    no_dupes = []
+    # Brute-force sorting
+    for c in containers:
+        unique = True
+        for u in no_dupes:
+            if (c.type, c.id, c.sort) == (u.type, u.id, u.sort):
+                unique = False
+        if unique or c.type == "random":
+            no_dupes.append(c)
+
+    return no_dupes
+
+
 def parse_input(sources):
     """Handle the parsing process of all provided input sources."""
     links = [s for s in sources if isinstance(s, str)]
     containers = [s for s in sources if not isinstance(s, str)]
+    containers = remove_container_dupes(containers)
 
     if opts.max_coubs:
         parsed = links[:opts.max_coubs]

--- a/coub.py
+++ b/coub.py
@@ -1179,6 +1179,13 @@ def normalize_link(string):
 
 def mapped_input(string):
     """Convert string provided by parse_cli() to valid input source."""
+    # Categorize existing paths as lists
+    # Otherwise the paths would be forced into a coub link like form
+    # which obviously leads to garbled nonsense
+    if os.path.exists(string):
+        path = valid_list(string)
+        return LinkList(path)
+
     link = normalize_link(string)
 
     if "https://coub.com/view/" in link:
@@ -1250,15 +1257,8 @@ def parse_cli():
         try:
             # Input
             if only_input or not fnmatch(opt, "-*"):
-                # Categorize existing paths as lists
-                # Otherwise they would be forced into a coub link like form
-                # which obviously leads to garbled nonsense
-                if os.path.exists(opt):
-                    opt = valid_list(opt)
-                    opts.input.append(LinkList(opt))
-                else:
-                    opt = mapped_input(opt)
-                    opts.input.append(opt)
+                opt = mapped_input(opt)
+                opts.input.append(opt)
             elif opt in ("-i", "--id"):
                 arg = no_url(arg)
                 opts.input.append(f"https://coub.com/view/{arg}")


### PR DESCRIPTION
The latest development cycle focussed on CLI parsing and (again) input.

The following points summarize the most important changes.

Added:

-) argparse to handle CLI parsing
-) support for the "Featured" and "Coub of the Day" communities
-) support for the "Random" category
-) video stream repair (now only applied on broken streams)
-) CLI option to change the extension of the merged container
   (previously only an advanced option within the script)

Removed:

-) sort support for the --hot option (hot section downloads can still be
   sorted by using URL input)

Technical changes:

-) removed CoubInputData class
-) input was split into 2 categories: links and containers
   (containers have a common interface to either request a limited
   number or all available coub links)
-) default sort methods are now defined by each container class
-) appending or overwriting a list with --write-list became an advanced
   option and the default was reverted to overwriting